### PR TITLE
fix: adjust movie line breaking and padding

### DIFF
--- a/movie_manager/lib/view/movies_page.dart
+++ b/movie_manager/lib/view/movies_page.dart
@@ -144,69 +144,73 @@ class _MoviesPageState extends State<MoviesPage> {
   }
 
   Widget _buildMovieCard(Movie movie) {
-    return SizedBox(
-      width: 400,
-      height: 200,
-      child: Card(
-        elevation: 2,
-        margin: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-        child: InkWell(
-          onTap: () => _showMovieOptions(movie),
-          child: Padding(
-            padding: const EdgeInsets.all(8),
-            child: Row(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                ClipRRect(
-                  borderRadius: BorderRadius.circular(0),
-                  child: Image.network(
-                    movie.imageUrl,
-                    width: 120,
-                    fit: BoxFit.cover,
-                    errorBuilder: (_, __, ___) =>
-                    const Icon(Icons.broken_image, size: 80),
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      child: SizedBox(
+        height: 200,
+        child: Card(
+          elevation: 2,
+          child: InkWell(
+            onTap: () => _showMovieOptions(movie),
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(0),
+                    child: Image.network(
+                      movie.imageUrl,
+                      width: 120,
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) =>
+                      const Icon(Icons.broken_image, size: 80),
+                    ),
                   ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        movie.title,
-                        style: const TextStyle(
-                          fontWeight: FontWeight.bold,
-                          fontSize: 20,
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          movie.title,
+                          style: const TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 20,
+                          ),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
                         ),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        movie.genre,
-                        style:
-                        const TextStyle(color: Colors.grey, fontSize: 16),
-                      ),
-                      const SizedBox(height: 4),
-                      Text(
-                        '${movie.durationInMinutes} min',
-                        style:
-                        const TextStyle(color: Colors.grey, fontSize: 16),
-                      ),
-                      const SizedBox(height: 8),
-                      const Spacer(),
-                      RatingBarIndicator(
-                        rating: movie.rating,
-                        itemBuilder: (context, index) => const Icon(
-                          Icons.star,
-                          color: Colors.amber,
+                        const SizedBox(height: 4),
+                        Text(
+                          movie.genre,
+                          style: const TextStyle(color: Colors.grey, fontSize: 16),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
-                        itemCount: 5,
-                        itemSize: 28.0,
-                        direction: Axis.horizontal,
-                      ),
-                    ],
+                        const SizedBox(height: 4),
+                        Text(
+                          '${movie.durationInMinutes} min',
+                          style:
+                          const TextStyle(color: Colors.grey, fontSize: 16),
+                        ),
+                        const SizedBox(height: 8),
+                        const Spacer(),
+                        RatingBarIndicator(
+                          rating: movie.rating,
+                          itemBuilder: (context, index) => const Icon(
+                            Icons.star,
+                            color: Colors.amber,
+                          ),
+                          itemCount: 5,
+                          itemSize: 28.0,
+                          direction: Axis.horizontal,
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
           ),
         ),


### PR DESCRIPTION
# 📌 Description

This Pr fix the line breaking of the movie tittle, it also adds a 1 line max to genre line.

It also adjusts the padding of the card, to go from one side to another of the screen.

# 🛠 Type of change

Select one or more options:

- [x] 🚑 Bug fix
- [ ] ✨ New feature
- [ ] 🔁 Refactor
- [ ] 📚 Documentation update
- [ ] 🔧 Config/Infrastructure adjustment
- [ ] 🧪 Automated tests
- [ ] Other: <!-- describe -->

# ✅ Checklist

- [x] The PR is up to date with `main`
- [x] Tested locally and works as expected
- [x] Existing tests are not broken
- [ ] Added/updated relevant tests
- [ ] Updated documentation if needed
- [x] Followed code style guidelines (lint/prettier/etc)
- [ ] Documented complex or critical parts of the code

# 📝 Tested scenarios
![image](https://github.com/user-attachments/assets/141fc305-d090-4645-955e-a3ae3d247d38)

Screenshots (if applicable):


# 🧩 Related issues

Closes #16 


# 🔍 Additional notes

<!--
Include any relevant notes for reviewers.
Example: "This PR depends on #45 which changes the database schema."
-->
